### PR TITLE
Migrate from master-slave language

### DIFF
--- a/circuito_config/admin.py
+++ b/circuito_config/admin.py
@@ -16,7 +16,7 @@ class DatalogAdmin(admin.ModelAdmin):
     list_display = ('id', 'valor', 'parametro_unidade', 'datahora','parametro', 'parametro_nome',)
     list_filter = (
         ('parametro__modulo__circuito__nome'),
-        ('parametro__modulo__no_slave'),
+        ('parametro__modulo__no_subordinate'),
         ('parametro__nome')
     )
 
@@ -32,7 +32,7 @@ class LogerrosAdmin(admin.ModelAdmin):
 
 @admin.register(models.Superaquecimentoconfig)
 class SuperaquecimentoconfigAdmin(admin.ModelAdmin):
-    list_display = ('nome', 'succao_no_slave', 'succao_no_parametro', 'evaporacao_no_slave', 'evaporacao_no_parametro', 'min_superaquecimento', 'max_superaquecimento')
+    list_display = ('nome', 'succao_no_subordinate', 'succao_no_parametro', 'evaporacao_no_subordinate', 'evaporacao_no_parametro', 'min_superaquecimento', 'max_superaquecimento')
 
 @admin.register(models.Superaquecimentolog)
 class SuperaquecimentologAdmin(admin.ModelAdmin):

--- a/circuito_config/cron-bk.py
+++ b/circuito_config/cron-bk.py
@@ -11,7 +11,7 @@ def my_scheduled_job():
 
         try:
             instrument = minimalmodbus.Instrument(parametro.modulo.circuito.porta,
-                                                  parametro.modulo.no_slave)  # port name, slave address (in decimal)
+                                                  parametro.modulo.no_subordinate)  # port name, subordinate address (in decimal)
 
             instrument.serial.baudrate = parametro.modulo.circuito.baudrate  # Baud
             instrument.serial.parity = parametro.modulo.circuito.parity
@@ -42,7 +42,7 @@ def my_scheduled_job():
                 datalog.valor = register
                 datalog.save()
             except:
-                mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(parametro.modulo.no_slave) + ' nao encontrado'
+                mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(parametro.modulo.no_subordinate) + ' nao encontrado'
                 erro = Logerros(cod='TG001', descricao=mensagem)
                 erro.save()
         except:

--- a/circuito_config/cron.py
+++ b/circuito_config/cron.py
@@ -10,7 +10,7 @@ def my_scheduled_job():
         # print(modulo)
         try:
             instrument = minimalmodbus.Instrument(modulo.circuito.porta,
-                                                  modulo.no_slave)  # port name, slave address (in decimal)
+                                                  modulo.no_subordinate)  # port name, subordinate address (in decimal)
 
             instrument.serial.baudrate = modulo.circuito.baudrate  # Baud
             instrument.serial.parity = modulo.circuito.parity
@@ -45,7 +45,7 @@ def my_scheduled_job():
 
                 except:
                     mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(
-                        parametro.modulo.no_slave) + ' nao encontrado'
+                        parametro.modulo.no_subordinate) + ' nao encontrado'
                     erro = Logerros(cod='TG001', descricao=mensagem)
                     erro.save()
                     #print(mensagem)

--- a/circuito_config/cronsuperaquecimento.py
+++ b/circuito_config/cronsuperaquecimento.py
@@ -12,7 +12,7 @@ def my_scheduled_job():
 
 
         try:
-            modulo_succao = Modulo.objects.get(no_slave=superaquecimentoconfig.succao_no_slave)
+            modulo_succao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.succao_no_subordinate)
             try:
                 parametro = Parametro.objects.get(modulo=modulo_succao, endereco=superaquecimentoconfig.succao_no_parametro)
                 try:
@@ -21,17 +21,17 @@ def my_scheduled_job():
 
                 except:
                     mensagem = 'calculo do superaquecimento - Datalog referente ao parametro ' + str(parametro.endereco) + ' do modulo ' + str(
-                            parametro.modulo.no_slave) + ' referente a SUCCAO nao encontrado'
+                            parametro.modulo.no_subordinate) + ' referente a SUCCAO nao encontrado'
                     #erro = Logerros(cod='TG006', descricao=mensagem)
                     #erro.save()
                     print(mensagem)
             except:
-                mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_slave) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
+                mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_subordinate) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
                 # erro = Logerros(cod='TG005', descricao=mensagem)
                 # erro.save()
                 print(mensagem)
         except:
-            mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_slave) + ' não cadastrado'
+            mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_subordinate) + ' não cadastrado'
             # erro = Logerros(cod='TG004', descricao=mensagem)
             # erro.save()
             print(mensagem)
@@ -39,7 +39,7 @@ def my_scheduled_job():
 
 
         try:
-            modulo_evaporacao = Modulo.objects.get(no_slave=superaquecimentoconfig.evaporacao_no_slave)
+            modulo_evaporacao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.evaporacao_no_subordinate)
             try:
                 parametro = Parametro.objects.get(modulo=modulo_evaporacao,
                                                   endereco=superaquecimentoconfig.evaporacao_no_parametro)
@@ -50,20 +50,20 @@ def my_scheduled_job():
                 except:
                     mensagem = 'calculo do superaquecimento - Datalog referente ao parametro ' + str(
                         parametro.endereco) + ' do modulo ' + str(
-                        parametro.modulo.no_slave) + ' referente a EVAPORACAO, nao encontrado'
+                        parametro.modulo.no_subordinate) + ' referente a EVAPORACAO, nao encontrado'
                     erro = Logerros(cod='TG006', descricao=mensagem)
                     erro.save()
                     # print(mensagem)
             except:
                 mensagem = 'calculo do superaquecimento - modulo: ' + str(
-                    modulo_evaporacao.no_slave) + 'parametro de número: ' + str(
+                    modulo_evaporacao.no_subordinate) + 'parametro de número: ' + str(
                     superaquecimentoconfig.evaporacao_no_parametro) + ' referente a EVAPORACAO não encontrado'
                 erro = Logerros(cod='TG005', descricao=mensagem)
                 erro.save()
                 # print(mensagem)
         except:
             mensagem = 'calculo do superaquecimento - modulo succao ' + str(
-                superaquecimentoconfig.succao_no_slave) + ' não cadastrado'
+                superaquecimentoconfig.succao_no_subordinate) + ' não cadastrado'
             erro = Logerros(cod='TG004', descricao=mensagem)
             erro.save()
             # print(mensagem)

--- a/circuito_config/management/commands/lerparametro.py
+++ b/circuito_config/management/commands/lerparametro.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
             try:
                 instrument = minimalmodbus.Instrument(parametro.modulo.circuito.porta,
-                                                      parametro.modulo.no_slave)  # port name, slave address (in decimal)
+                                                      parametro.modulo.no_subordinate)  # port name, subordinate address (in decimal)
 
                 instrument.serial.baudrate = parametro.modulo.circuito.baudrate  # Baud
                 instrument.serial.parity = parametro.modulo.circuito.parity
@@ -48,7 +48,7 @@ class Command(BaseCommand):
                     datalog.valor = register
                     datalog.save()
                 except:
-                    mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(parametro.modulo.no_slave) + ' nao encontrado'
+                    mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(parametro.modulo.no_subordinate) + ' nao encontrado'
                     erro = Logerros(cod='TG001', descricao=mensagem)
                     erro.save()
             except:

--- a/circuito_config/management/commands/lerparametro2.py
+++ b/circuito_config/management/commands/lerparametro2.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             #print(modulo)
             try:
                 instrument = minimalmodbus.Instrument(modulo.circuito.porta,
-                                                      modulo.no_slave)  # port name, slave address (in decimal)
+                                                      modulo.no_subordinate)  # port name, subordinate address (in decimal)
 
                 instrument.serial.baudrate = modulo.circuito.baudrate  # Baud
                 instrument.serial.parity = modulo.circuito.parity
@@ -54,7 +54,7 @@ class Command(BaseCommand):
 
                     except:
                         mensagem = 'parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(
-                            parametro.modulo.no_slave) + ' nao encontrado'
+                            parametro.modulo.no_subordinate) + ' nao encontrado'
                         erro = Logerros(cod='TG001', descricao=mensagem)
                         erro.save()
             except:

--- a/circuito_config/management/commands/superaquecimento.py
+++ b/circuito_config/management/commands/superaquecimento.py
@@ -16,10 +16,10 @@ class Command(BaseCommand):
             succao = 0
             evaporacao = 0
             try:
-                modulo_succao = Modulo.objects.get(no_slave=superaquecimentoconfig.succao_no_slave)
+                modulo_succao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.succao_no_subordinate)
                 try:
                     instrument = minimalmodbus.Instrument(modulo_succao.circuito.porta,
-                                                          modulo_succao.no_slave)  # port name, slave address (in decimal)
+                                                          modulo_succao.no_subordinate)  # port name, subordinate address (in decimal)
 
                     instrument.serial.baudrate = modulo_succao.circuito.baudrate  # Baud
                     instrument.serial.parity = modulo_succao.circuito.parity
@@ -46,13 +46,13 @@ class Command(BaseCommand):
 
                         except:
                             mensagem = 'calculo do superaquecimento - parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(
-                                parametro.modulo.no_slave) + ' nao encontrado'
+                                parametro.modulo.no_subordinate) + ' nao encontrado'
                             #erro = Logerros(cod='TG006', descricao=mensagem)
                             #erro.save()
                             print(mensagem)
 
                     except:
-                        mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_slave) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
+                        mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_subordinate) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
                         # erro = Logerros(cod='TG005', descricao=mensagem)
                         # erro.save()
                         print(mensagem)
@@ -62,16 +62,16 @@ class Command(BaseCommand):
                     # erro.save()
                     print(mensagem)
             except:
-                mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_slave) + ' não cadastrado'
+                mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_subordinate) + ' não cadastrado'
                 # erro = Logerros(cod='TG004', descricao=mensagem)
                 # erro.save()
                 print(mensagem)
 
             try:
-                modulo_evaporacao = Modulo.objects.get(no_slave=superaquecimentoconfig.evaporacao_no_slave)
+                modulo_evaporacao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.evaporacao_no_subordinate)
 
                 try:
-                    instrument = minimalmodbus.Instrument(modulo_evaporacao.circuito.porta, modulo_evaporacao.no_slave)  # port name, slave address (in decimal)
+                    instrument = minimalmodbus.Instrument(modulo_evaporacao.circuito.porta, modulo_evaporacao.no_subordinate)  # port name, subordinate address (in decimal)
 
                     instrument.serial.baudrate = modulo_evaporacao.circuito.baudrate  # Baud
                     instrument.serial.parity = modulo_evaporacao.circuito.parity
@@ -97,13 +97,13 @@ class Command(BaseCommand):
 
                         except:
                             mensagem = 'calculo do superaquecimento - parametro de endereco ' + str(parametro.endereco) + ' do modulo ' + str(
-                                parametro.modulo.no_slave) + 'referente a EVAPORACAO nao encontrado'
+                                parametro.modulo.no_subordinate) + 'referente a EVAPORACAO nao encontrado'
                             #erro = Logerros(cod='TG006', descricao=mensagem)
                             #erro.save()
                             print(mensagem)
 
                     except:
-                        mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_evaporacao.no_slave) + 'parametro de número: ' + str(superaquecimentoconfig.evaporacao_no_parametro) + ' não encontrado'
+                        mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_evaporacao.no_subordinate) + 'parametro de número: ' + str(superaquecimentoconfig.evaporacao_no_parametro) + ' não encontrado'
                         # erro = Logerros(cod='TG005', descricao=mensagem)
                         # erro.save()
                         print(mensagem)
@@ -113,7 +113,7 @@ class Command(BaseCommand):
                     # erro.save()
                     print(mensagem)
             except:
-                mensagem = 'calculo do superaquecimento - modulo evaporacao ' + str(superaquecimentoconfig.evaporacao_no_slave) + ' não cadastrado'
+                mensagem = 'calculo do superaquecimento - modulo evaporacao ' + str(superaquecimentoconfig.evaporacao_no_subordinate) + ' não cadastrado'
                 # erro = Logerros(cod='TG004', descricao=mensagem)
                 # erro.save()
                 print(mensagem)

--- a/circuito_config/management/commands/superaquecimento2.py
+++ b/circuito_config/management/commands/superaquecimento2.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 
             '''
             try:
-                modulo_succao = Modulo.objects.get(no_slave=superaquecimentoconfig.succao_no_slave)
+                modulo_succao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.succao_no_subordinate)
                 try:
                     parametro = Parametro.objects.get(modulo=modulo_succao, endereco=superaquecimentoconfig.succao_no_parametro)
                     try:
@@ -31,17 +31,17 @@ class Command(BaseCommand):
 
                     except:
                         mensagem = 'calculo do superaquecimento - Datalog referente ao parametro ' + str(parametro.endereco) + ' do modulo ' + str(
-                                parametro.modulo.no_slave) + ' referente a SUCCAO nao encontrado'
+                                parametro.modulo.no_subordinate) + ' referente a SUCCAO nao encontrado'
                         #erro = Logerros(cod='TG006', descricao=mensagem)
                         #erro.save()
                         print(mensagem)
                 except:
-                    mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_slave) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
+                    mensagem = 'calculo do superaquecimento - modulo: ' + str(modulo_succao.no_subordinate) + 'parametro de número: ' + str(superaquecimentoconfig.succao_no_parametro) + ' referente a SUCCAO não encontrado'
                     # erro = Logerros(cod='TG005', descricao=mensagem)
                     # erro.save()
                     print(mensagem)
             except:
-                mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_slave) + ' não cadastrado'
+                mensagem = 'calculo do superaquecimento - modulo succao ' + str(superaquecimentoconfig.succao_no_subordinate) + ' não cadastrado'
                 # erro = Logerros(cod='TG004', descricao=mensagem)
                 # erro.save()
                 print(mensagem)
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             '''
 
             try:
-                modulo_evaporacao = Modulo.objects.get(no_slave=superaquecimentoconfig.evaporacao_no_slave)
+                modulo_evaporacao = Modulo.objects.get(no_subordinate=superaquecimentoconfig.evaporacao_no_subordinate)
                 try:
                     parametro = Parametro.objects.get(modulo=modulo_evaporacao,
                                                       endereco=superaquecimentoconfig.evaporacao_no_parametro)
@@ -60,20 +60,20 @@ class Command(BaseCommand):
                     except:
                         mensagem = 'calculo do superaquecimento - Datalog referente ao parametro ' + str(
                             parametro.endereco) + ' do modulo ' + str(
-                            parametro.modulo.no_slave) + ' referente a EVAPORACAO, nao encontrado'
+                            parametro.modulo.no_subordinate) + ' referente a EVAPORACAO, nao encontrado'
                         erro = Logerros(cod='TG006', descricao=mensagem)
                         erro.save()
                         #print(mensagem)
                 except:
                     mensagem = 'calculo do superaquecimento - modulo: ' + str(
-                        modulo_evaporacao.no_slave) + 'parametro de número: ' + str(
+                        modulo_evaporacao.no_subordinate) + 'parametro de número: ' + str(
                         superaquecimentoconfig.evaporacao_no_parametro) + ' referente a EVAPORACAO não encontrado'
                     erro = Logerros(cod='TG005', descricao=mensagem)
                     erro.save()
                     #print(mensagem)
             except:
                 mensagem = 'calculo do superaquecimento - modulo succao ' + str(
-                    superaquecimentoconfig.succao_no_slave) + ' não cadastrado'
+                    superaquecimentoconfig.succao_no_subordinate) + ' não cadastrado'
                 erro = Logerros(cod='TG004', descricao=mensagem)
                 erro.save()
                 #print(mensagem)

--- a/circuito_config/migrations/0001_initial.py
+++ b/circuito_config/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('fabricante', models.CharField(max_length=100)),
                 ('modelo', models.CharField(max_length=100)),
                 ('patrimonio', models.CharField(blank=True, max_length=100, null=True)),
-                ('no_slave', models.IntegerField()),
+                ('no_subordinate', models.IntegerField()),
                 ('porta', models.CharField(max_length=255)),
                 ('baudrate', models.IntegerField()),
                 ('parity', models.CharField(choices=[('N', 'None'), ('E', 'Even'), ('O', 'Odd'), ('M', 'Mark'), ('S', 'Space')], default='N', max_length=1)),

--- a/circuito_config/migrations/0009_superaquecimentoconfig_superaquecimentolog.py
+++ b/circuito_config/migrations/0009_superaquecimentoconfig_superaquecimentolog.py
@@ -16,9 +16,9 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('nome', models.CharField(max_length=100)),
-                ('succao_no_slave', models.IntegerField()),
+                ('succao_no_subordinate', models.IntegerField()),
                 ('succao_no_parametro', models.IntegerField()),
-                ('evaporacao_no_slave', models.IntegerField()),
+                ('evaporacao_no_subordinate', models.IntegerField()),
                 ('evaporacao_no_parametro', models.IntegerField()),
             ],
         ),

--- a/circuito_config/models.py
+++ b/circuito_config/models.py
@@ -44,10 +44,10 @@ class Modulo(models.Model):
     fabricante = models.CharField(max_length=100)
     modelo = models.CharField(max_length=100)
     patrimonio = models.CharField(max_length=100, null=True, blank=True)
-    no_slave = models.IntegerField()
+    no_subordinate = models.IntegerField()
 
     def __str__(self):
-        return str(self.no_slave)
+        return str(self.no_subordinate)
 
 
 class Parametro(models.Model):
@@ -109,9 +109,9 @@ class Logerros(models.Model):
 
 class Superaquecimentoconfig(models.Model):
     nome = models.CharField(max_length=100)
-    succao_no_slave = models.IntegerField()
+    succao_no_subordinate = models.IntegerField()
     succao_no_parametro = models.IntegerField()
-    evaporacao_no_slave = models.IntegerField()
+    evaporacao_no_subordinate = models.IntegerField()
     evaporacao_no_parametro = models.IntegerField()
     min_superaquecimento = models.FloatField(default=0)
     max_superaquecimento = models.FloatField(default=0)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.